### PR TITLE
Fixed frequency bug

### DIFF
--- a/bot_python_sdk/frequency.py
+++ b/bot_python_sdk/frequency.py
@@ -17,12 +17,12 @@ class Frequency(Enum):
 
 
 FrequenciesInSeconds = {
-    Frequency.ALWAYS: 0,
-    Frequency.YEARLY: 31536000,  # Based on 365 days
-    Frequency.HALF_YEARLY: 15768000,  # Half of yearly
-    Frequency.MONTHLY: 2419200,  # Based on 28 days
-    Frequency.WEEKLY: 604800,
-    Frequency.DAILY: 86400,
-    Frequency.HOURLY: 3600,
-    Frequency.MINUTELY: 60
+    Frequency.ALWAYS.value: 0,
+    Frequency.YEARLY.value: 31536000,  # Based on 365 days
+    Frequency.HALF_YEARLY.value: 15768000,  # Half of yearly
+    Frequency.MONTHLY.value: 2419200,  # Based on 28 days
+    Frequency.WEEKLY.value: 604800,
+    Frequency.DAILY.value: 86400,
+    Frequency.HOURLY.value: 3600,
+    Frequency.MINUTELY.value: 60
 }


### PR DESCRIPTION
Posting an action to the SDK works fine the first time and the action is performed. However, the second time this action will not trigger and I get the message: 
`Action Service: Frequency not supported: minutely`

This is probably caused by:

https://github.com/BankingofThings/BoT-Python-SDK/blob/13a4ec5ab98729e6191b8853d61737af89e512e9/bot_python_sdk/action_service.py#L64-L65

The `Frequency.is_valid` method always returns False for string inputs because the dictionary is like this:
https://github.com/BankingofThings/BoT-Python-SDK/blob/13a4ec5ab98729e6191b8853d61737af89e512e9/bot_python_sdk/frequency.py#L19-L28

The first time it does work because of this line:
https://github.com/BankingofThings/BoT-Python-SDK/blob/13a4ec5ab98729e6191b8853d61737af89e512e9/bot_python_sdk/action_service.py#L61-L62

This Pull Request fixed it.