### PR TITLE
exception fixed while retrieving pairing device info

### DIFF
--- a/bot_python_sdk/api.py
+++ b/bot_python_sdk/api.py
@@ -1,5 +1,6 @@
 import falcon
 import subprocess
+import json
 
 from bot_python_sdk.action_service import ActionService
 from bot_python_sdk.configuration_service import ConfigurationService
@@ -67,7 +68,7 @@ class PairingResource:
             error = 'Device is already paired.'
             Logger.error(LOCATION, error)
             raise falcon.HTTPForbidden(description=error)
-        response.media = configuration.get_device_information
+        response.media = json.dumps(configuration.get_device_information)
         subprocess.Popen(['make', 'pair'])
 
 


### PR DESCRIPTION
Fixed the following exception:
File /home/pi/finn/BoT-Python-SDK/venv/lib/python3.4/site-packages/gunicorn/workers/sync.py, line 135, in handle
self.handle_request(listener, req, client, addr)
File /home/pi/finn/BoT-Python-SDK/venv/lib/python3.4/site-packages/gunicorn/workers/sync.py, line 176, in handle_request
respiter = self.wsgi(environ, resp.start_response)
File /home/pi/finn/BoT-Python-SDK/venv/lib/python3.4/site-packages/falcon/api.py, line 244, in call
responder(req, resp, *params)
File /home/pi/finn/BoT-Python-SDK/bot_python_sdk/api.py, line 76, in on_get
response.media = configuration.get_device_information
File /home/pi/finn/BoT-Python-SDK/venv/lib/python3.4/site-packages/falcon/response.py, line 183, in media
self.data = handler.serialize(self.media)
File /home/pi/finn/BoT-Python-SDK/venv/lib/python3.4/site-packages/falcon/media/json.py, line 23, in serialize
result = json.dumps(media, ensureascii=False)
File /usr/lib/python3.4/json/__init__.py, line 237, in dumps
*kw).encode(obj)
File /usr/lib/python3.4/json/encoder.py, line 192, in encode
chunks = self.iterencode(o, one_shot=True)
File /usr/lib/python3.4/json/encoder.py, line 250, in iterencode
return _iterencode(o, 0)
File /usr/lib/python3.4/json/encoder.py, line 173, in default
raise TypeError(repr(o) + is not JSON serializable)
TypeError: <bound method Configuration.getdevice_information of <bot_python_sdk.configuration.Configuration object at 0x75bd8990>> is not JSON serializable