### PR TITLE
qr code security addition and fixed the issue pairing device information coming as empty

### DIFF
--- a/bot_python_sdk/api.py
+++ b/bot_python_sdk/api.py
@@ -68,7 +68,8 @@ class PairingResource:
             error = 'Device is already paired.'
             Logger.error(LOCATION, error)
             raise falcon.HTTPForbidden(description=error)
-        response.media = json.dumps(configuration.get_device_information)
+        device_information = configuration.get_device_information()
+        response.media = json.dumps(device_information)
         subprocess.Popen(['make', 'pair'])
 
 

--- a/bot_python_sdk/configuration_service.py
+++ b/bot_python_sdk/configuration_service.py
@@ -1,6 +1,5 @@
 import json
 import qrcode
-import base64
 from qrcode.image.pure import PymagingImage
 from bot_python_sdk.activation_service import ActivationService
 from bot_python_sdk.configuration_store import ConfigurationStore
@@ -55,9 +54,7 @@ class ConfigurationService:
         try:
             Logger.info(LOCATION, 'Generating QR Code for alternative pairing...')
             device_information = self.configuration.get_device_information()
-            device_info_serialize = json.dumps(device_information)
-            device_info_encoded = device_info_serialize.encode("utf-8")
-            image = qrcode.make(base64.standard_b64encode(device_info_encoded), image_factory=PymagingImage)
+            image = qrcode.make(json.dumps(device_information), image_factory=PymagingImage)
             Store.save_qrcode(image)
             Logger.success(LOCATION, 'QR Code successfully generated')
         except Exception as exception:

--- a/bot_python_sdk/configuration_service.py
+++ b/bot_python_sdk/configuration_service.py
@@ -1,5 +1,6 @@
 import json
 import qrcode
+import base64
 from qrcode.image.pure import PymagingImage
 from bot_python_sdk.activation_service import ActivationService
 from bot_python_sdk.configuration_store import ConfigurationStore
@@ -54,7 +55,9 @@ class ConfigurationService:
         try:
             Logger.info(LOCATION, 'Generating QR Code for alternative pairing...')
             device_information = self.configuration.get_device_information()
-            image = qrcode.make(json.dumps(device_information), image_factory=PymagingImage)
+            device_info_serialize = json.dumps(device_information)
+            device_info_encoded = device_info_serialize.encode("utf-8")
+            image = qrcode.make(base64.standard_b64encode(device_info_encoded), image_factory=PymagingImage)
             Store.save_qrcode(image)
             Logger.success(LOCATION, 'QR Code successfully generated')
         except Exception as exception:


### PR DESCRIPTION
As a suggestion ,I added security encoding before creating QR code. The same decoding has to be implemented  wherever QR code  info is reading .Also fixed the issue of pairing device information coming as empty when we try to retrieve the device information from localhost.