### PR TITLE
Fixes to address IP, /qrcode and activation end point fix

### DIFF
--- a/bot_python_sdk/api.py
+++ b/bot_python_sdk/api.py
@@ -1,9 +1,12 @@
 import falcon
 import subprocess
 import json
+import os
+import platform
 from bot_python_sdk.action_service import ActionService
 from bot_python_sdk.configuration_service import ConfigurationService
 from bot_python_sdk.configuration_store import ConfigurationStore
+from bot_python_sdk.pairing_service import PairingService
 from bot_python_sdk.device_status import DeviceStatus
 from bot_python_sdk.logger import Logger
 
@@ -23,7 +26,9 @@ METHOD_POST = 'POST'
 ACTIONS_ENDPOINT = '/actions'
 PAIRING_ENDPOINT = '/pairing'
 ACTIVATION_ENDPOINT = '/activation'
+QRCODE_ENDPOINT = '/qrcode'
 
+QRCODE_IMG_PATH = 'storage/qr.png'
 
 class ActionsResource:
     def __init__(self):
@@ -84,21 +89,65 @@ class PairingResource:
 class ActivationResource:
     def __init__(self):
         self.configuration_service = ConfigurationService()
+        self.configuration_store = ConfigurationStore()
 
-    def on_get(self):
-        self.configuration_service.resume_configuration()
+    def on_get(self, request, response):
+        Logger.info(LOCATION, "Serving Activation Request...")
+        configuration = self.configuration_store.get()
+        if configuration.get_device_status() is DeviceStatus.ACTIVE:
+            response.media = {'message': 'Device is already Active'}
+        else:
+            self.configuration_service.resume_configuration()
+
         
-        
+class QRCodeResource(object):
+    def __init__(self):
+        pass
+
+    def on_get(self, request, response):
+        Logger.info(LOCATION, "Serving QRCode Request...")
+        stream = open(QRCODE_IMG_PATH, 'rb')
+        content_length = os.path.getsize(QRCODE_IMG_PATH)
+        response.content_type = "image/png"
+        response.stream, response.content_length = stream, content_length
+ 
 api = application = falcon.API()
 api.add_route(ACTIONS_ENDPOINT, ActionsResource())
 api.add_route(PAIRING_ENDPOINT, PairingResource())
 api.add_route(ACTIVATION_ENDPOINT, ActivationResource())
+api.add_route(QRCODE_ENDPOINT, QRCodeResource())
 
-ConfigurationService().resume_configuration()
+configuration = ConfigurationStore().get();
+device_status = configuration.get_device_status()
+systemPlatform = platform.system()
+Logger.info(LOCATION, "Detected Platform System: "+systemPlatform)
+if device_status is DeviceStatus.ACTIVE:
+    Logger.info(LOCATION,"Device is already active, no need to further configure")
+    Logger.info(LOCATION,"Server is waiting for requests to serve...")
+elif device_status is DeviceStatus.PAIRED:
+    Logger.info(LOCATION, "Device state is PAIRED, resuming the configuration")
+    ConfigurationService().resume_configuration()
+elif device_status is DeviceStatus.MULTIPAIR:
+    Logger.info(LOCATION, "Device state is MULTIPAIR, checking it's pair status from service")
+    if PairingService().pair():
+        Logger.info(LOCATION, "Device is paired as MULTIPAIR, Server is waiting for requests to serve...")
+    else:
+        Logger.info(LOCATION, "Device is not paired as MULTIPAIR, Pair the device either using QRCode or Bluetooth Service through FINN Mobile App")
+        if systemPlatform != 'Darwin' and configuration.is_bluetooth_enabled():
+            from bot_python_sdk.bluetooth_service import BluetoothService
+            
+            #Initialize the Bluetooth service class to process
+            #handle BLE specific envents and callbacks
+            BluetoothService().initialize()
+        ConfigurationService().resume_configuration()
+else:
+    Logger.info(LOCATION, "Pair the device either using QRCode or Bluetooth Service through FINN Mobile App")
+    if systemPlatform != 'Darwin' and configuration.is_bluetooth_enabled():
+       from bot_python_sdk.bluetooth_service import BluetoothService
 
-if ConfigurationService().configuration.is_bluetooth_enabled():
-    from bot_python_sdk.bluetooth_service import BluetoothService
+       #Initialize the Bluetooth service class to process
+       #handle BLE specific envents and callbacks
+       BluetoothService().initialize()
+    ConfigurationService().resume_configuration()
 
-    #Initialize the Bluetooth service class to process
-    #handle BLE specific envents and callbacks
-    BluetoothService().initialize()
+

--- a/bot_python_sdk/api.py
+++ b/bot_python_sdk/api.py
@@ -99,7 +99,7 @@ class ActivationResource:
         else:
             self.configuration_service.resume_configuration()
 
-        
+
 class QRCodeResource(object):
     def __init__(self):
         pass
@@ -110,44 +110,34 @@ class QRCodeResource(object):
         content_length = os.path.getsize(QRCODE_IMG_PATH)
         response.content_type = "image/png"
         response.stream, response.content_length = stream, content_length
- 
+
+def check_and_resume_configuration():
+    configuration = ConfigurationStore().get();
+    device_status = configuration.get_device_status()
+    systemPlatform = platform.system()
+    Logger.info(LOCATION, "Detected Platform System: "+systemPlatform)
+    if device_status is DeviceStatus.ACTIVE:
+        Logger.info(LOCATION,"Device is already active, no need to further configure")
+        Logger.info(LOCATION,"Server is waiting for requests to serve...")
+    elif device_status is DeviceStatus.PAIRED:
+        Logger.info(LOCATION, "Device state is PAIRED, resuming the configuration")
+        ConfigurationService().resume_configuration()
+    elif device_status is DeviceStatus.MULTIPAIR and PairingService().pair():
+        Logger.info(LOCATION, "Device is paired as MULTIPAIR, Server is waiting for requests to serve...")
+    else:
+        Logger.info(LOCATION, "Pair the device either using QRCode or Bluetooth Service through FINN Mobile App")
+        if systemPlatform != 'Darwin' and configuration.is_bluetooth_enabled():
+            from bot_python_sdk.bluetooth_service import BluetoothService
+            #Handle BLE specific events and callbacks
+            BluetoothService().initialize()
+            ConfigurationService().resume_configuration()
+
+#Start Webserver and add supported endpoint resources
 api = application = falcon.API()
 api.add_route(ACTIONS_ENDPOINT, ActionsResource())
 api.add_route(PAIRING_ENDPOINT, PairingResource())
 api.add_route(ACTIVATION_ENDPOINT, ActivationResource())
 api.add_route(QRCODE_ENDPOINT, QRCodeResource())
 
-configuration = ConfigurationStore().get();
-device_status = configuration.get_device_status()
-systemPlatform = platform.system()
-Logger.info(LOCATION, "Detected Platform System: "+systemPlatform)
-if device_status is DeviceStatus.ACTIVE:
-    Logger.info(LOCATION,"Device is already active, no need to further configure")
-    Logger.info(LOCATION,"Server is waiting for requests to serve...")
-elif device_status is DeviceStatus.PAIRED:
-    Logger.info(LOCATION, "Device state is PAIRED, resuming the configuration")
-    ConfigurationService().resume_configuration()
-elif device_status is DeviceStatus.MULTIPAIR:
-    Logger.info(LOCATION, "Device state is MULTIPAIR, checking it's pair status from service")
-    if PairingService().pair():
-        Logger.info(LOCATION, "Device is paired as MULTIPAIR, Server is waiting for requests to serve...")
-    else:
-        Logger.info(LOCATION, "Device is not paired as MULTIPAIR, Pair the device either using QRCode or Bluetooth Service through FINN Mobile App")
-        if systemPlatform != 'Darwin' and configuration.is_bluetooth_enabled():
-            from bot_python_sdk.bluetooth_service import BluetoothService
-            
-            #Initialize the Bluetooth service class to process
-            #handle BLE specific envents and callbacks
-            BluetoothService().initialize()
-        ConfigurationService().resume_configuration()
-else:
-    Logger.info(LOCATION, "Pair the device either using QRCode or Bluetooth Service through FINN Mobile App")
-    if systemPlatform != 'Darwin' and configuration.is_bluetooth_enabled():
-       from bot_python_sdk.bluetooth_service import BluetoothService
-
-       #Initialize the Bluetooth service class to process
-       #handle BLE specific envents and callbacks
-       BluetoothService().initialize()
-    ConfigurationService().resume_configuration()
-
-
+#Check and Configure the device
+check_and_resume_configuration()

--- a/bot_python_sdk/pairing_service.py
+++ b/bot_python_sdk/pairing_service.py
@@ -44,7 +44,9 @@ class PairingService:
     def pair(self):
         try:
             response = self.bot_service.get(RESOURCE)
+            Logger.info(LOCATION, 'Pairing Response: ' + str(response))
         except:
+            Logger.info(LOCATION, 'Pairing Response: ' + str(response))
             Logger.error(LOCATION, 'Failed pairing attempt.')
             return False
         if response['status'] is True:

--- a/bot_python_sdk/pairing_service.py
+++ b/bot_python_sdk/pairing_service.py
@@ -46,7 +46,6 @@ class PairingService:
             response = self.bot_service.get(RESOURCE)
             Logger.info(LOCATION, 'Pairing Response: ' + str(response))
         except:
-            Logger.info(LOCATION, 'Pairing Response: ' + str(response))
             Logger.error(LOCATION, 'Failed pairing attempt.')
             return False
         if response['status'] is True:

--- a/server.py
+++ b/server.py
@@ -18,10 +18,7 @@ def isValid(ip):
                 25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.(
                 25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)'''
 
-    if(re.search(regex, ip)):
-        return True
-    else:
-        return False
+    return re.search(regex, ip)
 
 
 if not store.has_configuration():
@@ -35,11 +32,11 @@ if os.name == 'nt':
     subprocess.run(['waitress-serve', '--port=3001', 'bot_python_sdk.api:api'])
 else:
     cmd = subprocess.Popen(['hostname', '-I'], stdout=subprocess.PIPE)
-    IPAddr = cmd.communicate()[0].decode('ascii').split(' ')[0]
-    if isValid(IPAddr):
-        Logger.info(LOCATION, "Detected IP Address :" +IPAddr)
+    ip = cmd.communicate()[0].decode('ascii').split(' ')[0]
+    if isValid(ip):
+        Logger.info(LOCATION, "Detected IP Address :" +ip)
     else:
         Logger.info(LOCATION, "Failed in detecting valid IP Address, using loop back address: 127.0.0.1")
-        IPAddr='127.0.0.1'
-    Logger.info(LOCATION, "Starting Webserver at URL: http://"+IPAddr+':3001/')
-    subprocess.run(['gunicorn', '-b', IPAddr+':3001', 'bot_python_sdk.api:api'])
+        ip='127.0.0.1'
+    Logger.info(LOCATION, "Starting Webserver at URL: http://"+ip+':3001/')
+    subprocess.run(['gunicorn', '-b', ip+':3001', 'bot_python_sdk.api:api'])

--- a/server.py
+++ b/server.py
@@ -18,4 +18,7 @@ if not store.has_configuration():
 if os.name == 'nt':
     subprocess.run(['waitress-serve', '--port=3001', 'bot_python_sdk.api:api'])
 else:
-    subprocess.run(['gunicorn', '-b', '127.0.0.1:3001', 'bot_python_sdk.api:api'])
+    cmd = subprocess.Popen(['hostname', '-I'], stdout=subprocess.PIPE)
+    IPAddr = cmd.communicate()[0].decode('ascii').split(' ')[0] 
+    print("Detected IP Address :" + IPAddr)
+    subprocess.run(['gunicorn', '-b', IPAddr+':3001', 'bot_python_sdk.api:api'])


### PR DESCRIPTION
The code changes has following fixes:

- Replace 127.0.0.1 with IP Address to enable board accessible remotely
- Fix bug in Activation on_get method
- Introduce new end point /qrcode for local webserver to enable remote device pairing
- Call resume configuration only if it's required in api.py
- Block BLE Service on macOS as it's not supported as of now